### PR TITLE
fix: skip validation for help and version commands

### DIFF
--- a/cmd/tscli/main.go
+++ b/cmd/tscli/main.go
@@ -37,6 +37,11 @@ func configureCLI() *cobra.Command {
 		Use:  "tscli",
 		Long: "A CLI tool for interacting with the Tailscale API.",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
+			// skip validation for "help" and "version" commands
+			if cmd.Name() == "help" || cmd.Name() == "version" {
+				return nil
+			}
+
 			_ = v.BindPFlags(cmd.Flags())
 			if v.GetString("api-key") == "" {
 				return fmt.Errorf("a Tailscale API key is required")


### PR DESCRIPTION
Skips the check for API key for the `help` and `version` commands.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skips API key validation for `help` and `version` commands in `cmd/tscli/main.go`.
> 
>   - **Behavior**:
>     - Skips API key validation for `help` and `version` commands in `cmd/tscli/main.go`.
>     - Adds conditional check in `PersistentPreRunE` function to bypass validation for these commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Ftscli&utm_source=github&utm_medium=referral)<sup> for 4dc7e10ab7eb80d455071bbc130c5cd277ffbb76. You can [customize](https://app.ellipsis.dev/jaxxstorm/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->