### PR TITLE
feat(logs): add command to fetch audit and network logs 

### DIFF
--- a/cmd/tscli/get/cli.go
+++ b/cmd/tscli/get/cli.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jaxxstorm/tscli/cmd/tscli/get/device"
 	"github.com/jaxxstorm/tscli/cmd/tscli/get/dns"
 	"github.com/jaxxstorm/tscli/cmd/tscli/get/key"
+	"github.com/jaxxstorm/tscli/cmd/tscli/get/logs"
 	"github.com/jaxxstorm/tscli/cmd/tscli/get/policy"
 	"github.com/jaxxstorm/tscli/cmd/tscli/get/posture"
 	"github.com/jaxxstorm/tscli/cmd/tscli/get/settings"
@@ -30,6 +31,7 @@ func Command() *cobra.Command {
 	command.AddCommand(settings.Command())
 	command.AddCommand(contacts.Command())
 	command.AddCommand(dns.Command())
+	command.AddCommand(logs.Command())
 
 	return command
 }

--- a/cmd/tscli/get/logs/cli.go
+++ b/cmd/tscli/get/logs/cli.go
@@ -1,0 +1,20 @@
+package logs
+
+import (
+	"github.com/jaxxstorm/tscli/cmd/tscli/get/logs/config"
+	"github.com/jaxxstorm/tscli/cmd/tscli/get/logs/network"
+	"github.com/spf13/cobra"
+)
+
+func Command() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "logs",
+		Short: "Get logs for the tailnet",
+		Long:  "Commands to retrieve configuration and network audit logs from the Tailscale API.",
+	}
+
+	command.AddCommand(config.Command())
+	command.AddCommand(network.Command())
+
+	return command
+}

--- a/cmd/tscli/get/logs/config/cli.go
+++ b/cmd/tscli/get/logs/config/cli.go
@@ -1,0 +1,74 @@
+// cmd/tscli/get/logs/config/cli.go
+//
+// Fetch configuration audit logs from the Tailscale API.
+//
+//	# Get configuration logs for a specific day
+//	tscli get logs config --start 2024-01-01T00:00:00Z --end 2024-01-01T23:59:59Z
+//
+//	# Get configuration logs for the last hour
+//	tscli get logs config --start $(date -d '1 hour ago' -Iseconds) --end $(date -Iseconds)
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/jaxxstorm/tscli/pkg/tscli"
+	"github.com/spf13/cobra"
+)
+
+func Command() *cobra.Command {
+	var (
+		startTime string
+		endTime   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Get configuration audit logs for the tailnet",
+		Long:  "List all configuration audit logs for a tailnet within a time range.",
+
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := tscli.New()
+			if err != nil {
+				return err
+			}
+
+			path := "/tailnet/{tailnet}/logging/configuration"
+			q := url.Values{}
+			q.Add("start", startTime)
+			q.Add("end", endTime)
+			path += "?" + q.Encode()
+
+			var resp json.RawMessage
+			if _, err := tscli.Do(
+				context.Background(),
+				client,
+				http.MethodGet,
+				path,
+				nil,
+				&resp,
+			); err != nil {
+				return err
+			}
+
+			pretty, _ := json.MarshalIndent(resp, "", "  ")
+			fmt.Fprintln(os.Stdout, string(pretty))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&startTime, "start", "s", "",
+		`Start time in RFC3339 format (required). Example: "2024-01-01T00:00:00Z"`)
+	cmd.Flags().StringVarP(&endTime, "end", "e", "",
+		`End time in RFC3339 format (required). Example: "2024-01-01T23:59:59Z"`)
+
+	_ = cmd.MarkFlagRequired("start")
+	_ = cmd.MarkFlagRequired("end")
+
+	return cmd
+}

--- a/cmd/tscli/get/logs/network/cli.go
+++ b/cmd/tscli/get/logs/network/cli.go
@@ -1,0 +1,74 @@
+// cmd/tscli/get/logs/network/cli.go
+//
+// Fetch network audit logs from the Tailscale API.
+//
+//	# Get network logs for a specific day
+//	tscli get logs network --start 2024-01-01T00:00:00Z --end 2024-01-01T23:59:59Z
+//
+//	# Get network logs for the last hour
+//	tscli get logs network --start $(date -d '1 hour ago' -Iseconds) --end $(date -Iseconds)
+package network
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/jaxxstorm/tscli/pkg/tscli"
+	"github.com/spf13/cobra"
+)
+
+func Command() *cobra.Command {
+	var (
+		startTime string
+		endTime   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "network",
+		Short: "Get network audit logs for the tailnet",
+		Long:  "List all network audit logs for a tailnet within a time range.",
+
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client, err := tscli.New()
+			if err != nil {
+				return err
+			}
+
+			path := "/tailnet/{tailnet}/logging/network"
+			q := url.Values{}
+			q.Add("start", startTime)
+			q.Add("end", endTime)
+			path += "?" + q.Encode()
+
+			var resp json.RawMessage
+			if _, err := tscli.Do(
+				context.Background(),
+				client,
+				http.MethodGet,
+				path,
+				nil,
+				&resp,
+			); err != nil {
+				return err
+			}
+
+			pretty, _ := json.MarshalIndent(resp, "", "  ")
+			fmt.Fprintln(os.Stdout, string(pretty))
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&startTime, "start", "s", "",
+		`Start time in RFC3339 format (required). Example: "2024-01-01T00:00:00Z"`)
+	cmd.Flags().StringVarP(&endTime, "end", "e", "",
+		`End time in RFC3339 format (required). Example: "2024-01-01T23:59:59Z"`)
+
+	_ = cmd.MarkFlagRequired("start")
+	_ = cmd.MarkFlagRequired("end")
+
+	return cmd
+}

--- a/pkg/tscli/client.go
+++ b/pkg/tscli/client.go
@@ -66,8 +66,18 @@ func Do(
 		b, _ := url.Parse(defaultBaseURL)
 		base = b
 	}
-	path = strings.ReplaceAll(path, "{tailnet}", url.PathEscape(c.Tailnet))
-	full := base.ResolveReference(&url.URL{Path: "/api/v2" + path})
+
+	u, err := url.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid path: %w", err)
+	}
+
+	u.Path = strings.ReplaceAll(u.Path, "{tailnet}", url.PathEscape(c.Tailnet))
+
+	full := base.ResolveReference(&url.URL{
+		Path:     "/api/v2" + u.Path,
+		RawQuery: u.RawQuery,
+	})
 
 	var rdr io.Reader
 	if body != nil {


### PR DESCRIPTION
Implements the missing audit logs retrieval functionality for the Tailscale CLI. This adds the tscli get logs command to fetch configuration audit or network logs via the Tailscale API.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `tscli get logs` command to fetch and display Tailscale audit logs with time range validation.
> 
>   - **New Command**:
>     - Adds `tscli get logs` command in `cmd/tscli/get/logs/cli.go` to fetch audit logs from Tailscale API.
>     - Requires `--start` and `--end` flags in RFC3339 format; validates time range (max 90 days).
>   - **Integration**:
>     - Registers `logs.Command()` in `cmd/tscli/get/cli.go`.
>   - **Functionality**:
>     - Fetches logs using HTTP GET request, handles API key authentication.
>     - Outputs logs in JSON format, ordered chronologically.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Ftscli&utm_source=github&utm_medium=referral)<sup> for 648b648268cdcb82b4ae2af5ff26edc272d804a1. You can [customize](https://app.ellipsis.dev/jaxxstorm/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->