### PR TITLE
perf: optimize regex compilation in ParseHumanDuration()

### DIFF
--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -7,11 +7,12 @@ import (
 	"time"
 )
 
+var durRE = regexp.MustCompile(`(\d+)([dhms])`)
+
 // Accepts sequences like “30d12h45m10s”. Supported units: d, h, m, s.
 func ParseHumanDuration(s string) (time.Duration, error) {
-	re := regexp.MustCompile(`(\d+)([dhms])`)
-	matches := re.FindAllStringSubmatch(s, -1)
-	if len(matches) == 0 || re.ReplaceAllString(s, "") != "" {
+	matches := durRE.FindAllStringSubmatch(s, -1)
+	if len(matches) == 0 || durRE.ReplaceAllString(s, "") != "" {
 		return 0, errors.New("bad duration")
 	}
 


### PR DESCRIPTION
- **add new output methods**
- **update log commands with new output**
- **allow human readable inputs for log commands**
- **update readme**
- **only compile refex once**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `ParseHumanDuration()` in `time.go` by compiling regex once to improve performance.
> 
>   - **Optimization**:
>     - Compile regular expression `durRE` once in `time.go` for `ParseHumanDuration()` to improve performance.
>   - **Functionality**:
>     - `ParseHumanDuration()` now uses precompiled `durRE` instead of recompiling regex each call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Ftscli&utm_source=github&utm_medium=referral)<sup> for 3804e619646080a69ac5cc660bb64511f9ad78a1. You can [customize](https://app.ellipsis.dev/jaxxstorm/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->