### PR TITLE
refactor: rename `format` to `output` for output configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ tscli --version
 # ~/.tscli/.tscli.yaml
 api-key: tskey-abc123…
 tailnet: example.com
-format: pretty # other options are: human, json or yaml
+output: pretty # other options are: human, json or yaml
 ```
 
 ## 🚀 Usage

--- a/cmd/tscli/config/show/cli.go
+++ b/cmd/tscli/config/show/cli.go
@@ -17,7 +17,7 @@ func Command() *cobra.Command {
 			config.WarnIfOverrides(cmd.ErrOrStderr(), cmd)
 
 			out, _ := json.MarshalIndent(viper.AllSettings(), "", "  ")
-			return output.Print(viper.GetString("format"), out)
+			return output.Print(viper.GetString("output"), out)
 		},
 	}
 	return cmd

--- a/cmd/tscli/create/integration/cli.go
+++ b/cmd/tscli/create/integration/cli.go
@@ -85,8 +85,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/create/invite/device/cli.go
+++ b/cmd/tscli/create/invite/device/cli.go
@@ -95,8 +95,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/create/invite/user/cli.go
+++ b/cmd/tscli/create/invite/user/cli.go
@@ -83,8 +83,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/create/key/cli.go
+++ b/cmd/tscli/create/key/cli.go
@@ -119,8 +119,8 @@ func Command() *cobra.Command {
 				return fmt.Errorf("create oauth client: %w", err)
 			}
 			out, _ := json.MarshalIndent(key, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/create/webhook/cli.go
+++ b/cmd/tscli/create/webhook/cli.go
@@ -116,8 +116,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(hook, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/delete/device/cli.go
+++ b/cmd/tscli/delete/device/cli.go
@@ -38,8 +38,8 @@ func Command() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal payload into JSON: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 
 		},

--- a/cmd/tscli/delete/invite/device/cli.go
+++ b/cmd/tscli/delete/invite/device/cli.go
@@ -44,8 +44,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 
 			return nil
 		},

--- a/cmd/tscli/delete/invite/user/cli.go
+++ b/cmd/tscli/delete/invite/user/cli.go
@@ -44,8 +44,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 
 			return nil
 		},

--- a/cmd/tscli/delete/posture/cli.go
+++ b/cmd/tscli/delete/posture/cli.go
@@ -56,8 +56,8 @@ func Command() *cobra.Command {
 				"result": fmt.Sprintf("device %s: %s deleted", deviceID, attrKey),
 			}
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/delete/user/cli.go
+++ b/cmd/tscli/delete/user/cli.go
@@ -45,8 +45,8 @@ func Command() *cobra.Command {
 				"result": fmt.Sprintf("user %s deleted", userID),
 			}
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/delete/webhook/cli.go
+++ b/cmd/tscli/delete/webhook/cli.go
@@ -35,8 +35,8 @@ func Command() *cobra.Command {
 			out, _ := json.MarshalIndent(map[string]string{
 				"result": fmt.Sprintf("webhook %s deleted", hookID),
 			}, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/contacts/cli.go
+++ b/cmd/tscli/get/contacts/cli.go
@@ -31,8 +31,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(c, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/device/cli.go
+++ b/cmd/tscli/get/device/cli.go
@@ -109,8 +109,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(dv, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/dns/nameservers/cli.go
+++ b/cmd/tscli/get/dns/nameservers/cli.go
@@ -41,8 +41,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(raw, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/dns/preferences/cli.go
+++ b/cmd/tscli/get/dns/preferences/cli.go
@@ -43,8 +43,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(raw, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/dns/searchpaths/cli.go
+++ b/cmd/tscli/get/dns/searchpaths/cli.go
@@ -42,8 +42,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(raw, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/dns/split/cli.go
+++ b/cmd/tscli/get/dns/split/cli.go
@@ -41,8 +41,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(raw, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/integration/cli.go
+++ b/cmd/tscli/get/integration/cli.go
@@ -45,8 +45,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(raw, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/key/cli.go
+++ b/cmd/tscli/get/key/cli.go
@@ -37,8 +37,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(raw, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/posture/cli.go
+++ b/cmd/tscli/get/posture/cli.go
@@ -49,8 +49,8 @@ Example
 			if err != nil {
 				return fmt.Errorf("failed to marshal JSON: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/settings/cli.go
+++ b/cmd/tscli/get/settings/cli.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/jaxxstorm/tscli/pkg/output"
 
 	"github.com/jaxxstorm/tscli/pkg/tscli"
@@ -36,8 +37,8 @@ func Command() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal settings: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/user/cli.go
+++ b/cmd/tscli/get/user/cli.go
@@ -36,8 +36,8 @@ func Command() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal user: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/get/webhook/cli.go
+++ b/cmd/tscli/get/webhook/cli.go
@@ -39,8 +39,8 @@ func Command() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal webhook: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/list/cli.go
+++ b/cmd/tscli/list/cli.go
@@ -5,11 +5,11 @@ import (
 	"github.com/jaxxstorm/tscli/cmd/tscli/list/integration"
 	"github.com/jaxxstorm/tscli/cmd/tscli/list/invites"
 	"github.com/jaxxstorm/tscli/cmd/tscli/list/keys"
+	"github.com/jaxxstorm/tscli/cmd/tscli/list/logs"
 	"github.com/jaxxstorm/tscli/cmd/tscli/list/nameservers"
 	"github.com/jaxxstorm/tscli/cmd/tscli/list/routes"
 	"github.com/jaxxstorm/tscli/cmd/tscli/list/users"
 	"github.com/jaxxstorm/tscli/cmd/tscli/list/webhooks"
-	"github.com/jaxxstorm/tscli/cmd/tscli/list/logs"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/tscli/list/devices/cli.go
+++ b/cmd/tscli/list/devices/cli.go
@@ -60,8 +60,8 @@ Examples
 			if err != nil {
 				return fmt.Errorf("failed to marshal devices into JSON: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/list/integration/cli.go
+++ b/cmd/tscli/list/integration/cli.go
@@ -40,8 +40,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/list/invites/device/cli.go
+++ b/cmd/tscli/list/invites/device/cli.go
@@ -65,8 +65,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(json.RawMessage(raw), "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/list/invites/user/cli.go
+++ b/cmd/tscli/list/invites/user/cli.go
@@ -63,8 +63,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/list/keys/cli.go
+++ b/cmd/tscli/list/keys/cli.go
@@ -42,8 +42,8 @@ func Command() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal keys into JSON: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/list/logs/network/cli.go
+++ b/cmd/tscli/list/logs/network/cli.go
@@ -25,7 +25,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-
 func Command() *cobra.Command {
 	var (
 		startFlag string

--- a/cmd/tscli/list/nameservers/cli.go
+++ b/cmd/tscli/list/nameservers/cli.go
@@ -37,8 +37,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(raw, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/list/routes/cli.go
+++ b/cmd/tscli/list/routes/cli.go
@@ -47,8 +47,8 @@ func Command() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal routes into JSON: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/list/users/cli.go
+++ b/cmd/tscli/list/users/cli.go
@@ -76,8 +76,8 @@ func Command() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal users: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/list/webhooks/cli.go
+++ b/cmd/tscli/list/webhooks/cli.go
@@ -30,8 +30,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(webhooks, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/main.go
+++ b/cmd/tscli/main.go
@@ -22,10 +22,10 @@ import (
 )
 
 var (
-	apiKey  string
-	tailnet string
-	debug   bool
-	format  string
+	apiKey     string
+	tailnet    string
+	debug      bool
+	outputType string
 )
 
 func configureCLI() *cobra.Command {
@@ -67,20 +67,20 @@ func configureCLI() *cobra.Command {
 		"",
 		"Tailscale API key")
 	root.PersistentFlags().StringVarP(
-		&format, "format", "f", "",
-		fmt.Sprintf("Output format: %v", output.Available()),
+		&outputType, "output", "f", "",
+		fmt.Sprintf("Output: %v", output.Available()),
 	)
 	root.PersistentFlags().StringVarP(&tailnet, "tailnet", "n", v.GetString("tailnet"), "Tailscale tailnet")
 
-	v.SetDefault("format", "json")
+	v.SetDefault("output", "json")
 
 	v.AutomaticEnv()
 	v.BindEnv("api-key", "TAILSCALE_API_KEY")
 	v.BindEnv("tailnet", "TAILSCALE_TAILNET")
-	v.BindEnv("format", "TSCLI_FORMAT")
+	v.BindEnv("output", "TSCLI_OUTPUT")
 	v.BindPFlag("api-key", root.PersistentFlags().Lookup("api-key"))
 	v.BindPFlag("tailnet", root.PersistentFlags().Lookup("tailnet"))
-	v.BindPFlag("format", root.PersistentFlags().Lookup("format"))
+	v.BindPFlag("output", root.PersistentFlags().Lookup("output"))
 	root.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Dump HTTP requests/responses")
 	v.BindPFlag("debug", root.PersistentFlags().Lookup("debug"))
 	v.BindEnv("debug", "TSCLI_DEBUG")

--- a/cmd/tscli/rotate/webhook/cli.go
+++ b/cmd/tscli/rotate/webhook/cli.go
@@ -39,8 +39,8 @@ func Command() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal webhook: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/authorization/cli.go
+++ b/cmd/tscli/set/authorization/cli.go
@@ -50,8 +50,8 @@ func Command() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed to marshal JSON: %w", err)
 			}
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/contact/cli.go
+++ b/cmd/tscli/set/contact/cli.go
@@ -64,8 +64,8 @@ func Command() *cobra.Command {
 				"type":   strings.ToLower(typeStr),
 				"email":  email,
 			}, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/dns/preferences/cli.go
+++ b/cmd/tscli/set/dns/preferences/cli.go
@@ -51,8 +51,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(raw, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 
 		},

--- a/cmd/tscli/set/dns/searchpaths/cli.go
+++ b/cmd/tscli/set/dns/searchpaths/cli.go
@@ -83,8 +83,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/dns/split/cli.go
+++ b/cmd/tscli/set/dns/split/cli.go
@@ -112,8 +112,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/expiry/cli.go
+++ b/cmd/tscli/set/expiry/cli.go
@@ -43,8 +43,8 @@ func Command() *cobra.Command {
 			// Print a simple JSON confirmation to stdout.
 			payload := map[string]string{"result": fmt.Sprintf("device %s expired", deviceID)}
 			out, _ := json.MarshalIndent(payload, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/integration/cli.go
+++ b/cmd/tscli/set/integration/cli.go
@@ -95,8 +95,8 @@ func Command() *cobra.Command {
 				"id":     id,
 				"fields": body,
 			}, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/ip/cli.go
+++ b/cmd/tscli/set/ip/cli.go
@@ -50,8 +50,8 @@ func Command() *cobra.Command {
 			out, _ := json.MarshalIndent(map[string]string{
 				"result": fmt.Sprintf("device %s IPv4 set to %s", deviceID, ipv4),
 			}, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/name/cli.go
+++ b/cmd/tscli/set/name/cli.go
@@ -36,8 +36,8 @@ func Command() *cobra.Command {
 			out, _ := json.MarshalIndent(map[string]string{
 				"result": fmt.Sprintf("device %s name set to %s", deviceID, newName),
 			}, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/posture/cli.go
+++ b/cmd/tscli/set/posture/cli.go
@@ -116,8 +116,8 @@ func Command() *cobra.Command {
 				"result": fmt.Sprintf("device %s: %s set to %v", deviceFlag, keyFlag, parsedValue),
 			}
 			out, _ := json.MarshalIndent(payload, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/routes/cli.go
+++ b/cmd/tscli/set/routes/cli.go
@@ -67,8 +67,8 @@ Examples
 				"routes": routes,
 			}
 			out, _ := json.MarshalIndent(resp, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/settings/cli.go
+++ b/cmd/tscli/set/settings/cli.go
@@ -94,8 +94,8 @@ func Command() *cobra.Command {
 			}
 
 			out, _ := json.MarshalIndent(req, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/tags/cli.go
+++ b/cmd/tscli/set/tags/cli.go
@@ -53,8 +53,8 @@ func Command() *cobra.Command {
 				"device": deviceID,
 				"tags":   tags,
 			}, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/user/access/cli.go
+++ b/cmd/tscli/set/user/access/cli.go
@@ -76,8 +76,8 @@ func Command() *cobra.Command {
 			out, _ := json.MarshalIndent(map[string]string{
 				"result": fmt.Sprintf("user %s %s", userID, msg),
 			}, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/set/user/role/cli.go
+++ b/cmd/tscli/set/user/role/cli.go
@@ -59,8 +59,8 @@ func Command() *cobra.Command {
 			out, _ := json.MarshalIndent(map[string]string{
 				"result": fmt.Sprintf("user %s role set to %s", userID, role),
 			}, "", "  ")
-			format := viper.GetString("format")
-			output.Print(format, out)
+			outputType := viper.GetString("output")
+			output.Print(outputType, out)
 			return nil
 		},
 	}

--- a/cmd/tscli/version/version.go
+++ b/cmd/tscli/version/version.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/jaxxstorm/tscli/pkg/version"
+	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/spf13/cobra"
 )
 


### PR DESCRIPTION
Signed-off-by: Lee Briggs <lee@leebriggs.co.uk>

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Rename configuration key `format` to `output` across multiple command files for consistent output configuration.
> 
>   - **Configuration Key Rename**:
>     - Rename configuration key `format` to `output` in `cmd/tscli/config/show/cli.go`, `cmd/tscli/create/integration/cli.go`, and `cmd/tscli/create/invite/device/cli.go`.
>     - Update `output.Print` calls to use `viper.GetString("output")` instead of `viper.GetString("format")` in 30+ files.
>   - **Miscellaneous**:
>     - Change import order in `cmd/tscli/list/cli.go` to maintain consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Ftscli&utm_source=github&utm_medium=referral)<sup> for e5f8c8c980a6463442e42036f017895fc9d12682. You can [customize](https://app.ellipsis.dev/jaxxstorm/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->