### PR TITLE
feat: add `create token` command for OAuth token generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ tscli <noun> <verb> [flags]
 | List tailnet keys                | :white_check_mark: | `tscli list keys` |
 | Create auth-key / OAuth client   | :white_check_mark: | `tscli create key --type authkey --oauthclient …` |
 | Get key                          | :white_check_mark: | `tscli get key --key <id>` |
+| Create a token                   | :white_check_mark: | `create token --client-id <oauth-client-id> --client-secret <oauth-client-secret>` |
 | Delete / revoke key              | :x: | — |
 | **Policy File**                  |        |                 |
 | Get policy file                  | :white_check_mark: | `tscli get policy [--json]` |

--- a/cmd/tscli/create/cli.go
+++ b/cmd/tscli/create/cli.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jaxxstorm/tscli/cmd/tscli/create/invite"
 	"github.com/jaxxstorm/tscli/cmd/tscli/create/key"
 	"github.com/jaxxstorm/tscli/cmd/tscli/create/webhook"
+	"github.com/jaxxstorm/tscli/cmd/tscli/create/token"
 	"github.com/spf13/cobra"
 )
 
@@ -19,6 +20,7 @@ func Command() *cobra.Command {
 	command.AddCommand(key.Command())
 	command.AddCommand(webhook.Command())
 	command.AddCommand(invite.Command())
+	command.AddCommand(token.Command())
 
 	return command
 }

--- a/cmd/tscli/create/token/cli.go
+++ b/cmd/tscli/create/token/cli.go
@@ -1,0 +1,92 @@
+// cmd/tscli/create/token/cli.go
+//
+// Exchange an OAuth client-id/secret for an access-token.
+//
+//   tscli create token --client-id XXX --client-secret YYY
+//
+package token
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/jaxxstorm/tscli/pkg/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const endpoint = "https://api.tailscale.com/api/v2/oauth/token"
+
+func Command() *cobra.Command {
+	var (
+		clientID     string
+		clientSecret string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "token",
+		Short: "Create an OAuth access-token from a client_id / client_secret pair",
+		Long:  "POSTs to /api/v2/oauth/token. No API-key auth is required.",
+		Example: `  tscli create token \
+      --client-id     "$OAUTH_CLIENT_ID" \
+      --client-secret "$OAUTH_CLIENT_SECRET"`,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			if clientID == "" || clientSecret == "" {
+				return errors.New("--client-id and --client-secret are both required")
+			}
+			return nil
+		},
+
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			/* ------------------------------------------------------ */
+			form := url.Values{}
+			form.Set("client_id", clientID)
+			form.Set("client_secret", clientSecret)
+
+			req, _ := http.NewRequest(http.MethodPost, endpoint,
+				bytes.NewBufferString(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("User-Agent", "tscli")
+
+			if viper.GetBool("debug") {
+				if dump, err := httputil.DumpRequestOut(req, true); err == nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "\n--- REQUEST ---\n%s\n", dump)
+				}
+			}
+
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+
+			if viper.GetBool("debug") {
+				if dump, err := httputil.DumpResponse(resp, true); err == nil {
+					fmt.Fprintf(cmd.ErrOrStderr(), "\n--- RESPONSE ---\n%s\n", dump)
+				}
+			}
+
+			body, _ := io.ReadAll(resp.Body)
+
+			/* ------------------------------------------------------ */
+			if resp.StatusCode/100 != 2 { // non-2xx
+				_ = output.Print(viper.GetString("format"), body)
+				return fmt.Errorf("tailscale API returned %s", resp.Status)
+			}
+
+			return output.Print(viper.GetString("format"), body)
+		},
+	}
+
+	cmd.Flags().StringVar(&clientID, "client-id", "", "OAuth client ID (required)")
+	cmd.Flags().StringVar(&clientSecret, "client-secret", "", "OAuth client secret (required)")
+	_ = cmd.MarkFlagRequired("client-id")
+	_ = cmd.MarkFlagRequired("client-secret")
+
+	return cmd
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `create token` command to generate OAuth tokens using client credentials, with documentation update.
> 
>   - **New Feature**:
>     - Adds `create token` command in `cmd/tscli/create/cli.go` to generate OAuth access tokens using client ID and secret.
>     - Implements token creation logic in `cmd/tscli/create/token/cli.go`, which sends a POST request to `/api/v2/oauth/token`.
>   - **Documentation**:
>     - Updates `README.md` to include `create token` command in the coverage table.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Ftscli&utm_source=github&utm_medium=referral)<sup> for 07034314c3247ebadd9386f5465b8ab342cf0422. You can [customize](https://app.ellipsis.dev/jaxxstorm/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->