### PR TITLE
[Feature] Add --include flag to delete devices option

### DIFF
--- a/cmd/tscli/delete/devices/cli.go
+++ b/cmd/tscli/delete/devices/cli.go
@@ -20,6 +20,8 @@ import (
 	tsapi "tailscale.com/client/tailscale/v2"
 )
 
+var newClient = tscli.New
+
 // DeletionResult represents the result of a device deletion operation
 type DeletionResult struct {
 	DeviceID   string
@@ -43,6 +45,7 @@ func Command() *cobra.Command {
 	var (
 		lastSeenDuration time.Duration
 		exclude          []string
+		include          []string
 		confirm          bool
 		ephemeral        bool
 	)
@@ -69,16 +72,24 @@ Examples:
   # Delete devices not seen for 24 hours, excluding specific patterns
   tscli delete devices --last-seen 24h --exclude server --exclude prod --confirm
 
+  # Delete only devices matching specific patterns
+  tscli delete devices --last-seen 24h --include dev --include test --confirm
+
   # Actually delete devices (requires --confirm)
   tscli delete devices --last-seen 15m --confirm
 `,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			client, err := tscli.New()
+			// Validate that exclude and include are mutually exclusive
+			if len(exclude) > 0 && len(include) > 0 {
+				return fmt.Errorf("--exclude and --include are mutually exclusive; use one or the other")
+			}
+
+			client, err := newClient()
 			if err != nil {
 				return fmt.Errorf("failed to create client: %w", err)
 			}
 
-			summary, err := deleteDisconnectedDevices(cmd.Context(), client, lastSeenDuration, exclude, ephemeral, confirm)
+			summary, err := deleteDisconnectedDevices(cmd.Context(), client, lastSeenDuration, exclude, include, ephemeral, confirm)
 			if err != nil {
 				return fmt.Errorf("failed to delete devices: %w", err)
 			}
@@ -98,6 +109,8 @@ Examples:
 		"Duration to consider a device disconnected (e.g., 15m, 1h, 24h)")
 	cmd.Flags().StringSliceVar(&exclude, "exclude", nil,
 		"Device names to exclude by partial match (can be specified multiple times)")
+	cmd.Flags().StringSliceVar(&include, "include", nil,
+		"Device names to include by partial match (can be specified multiple times)")
 	cmd.Flags().BoolVar(&ephemeral, "ephemeral", false,
 		"Only delete ephemeral devices")
 	cmd.Flags().BoolVar(&confirm, "confirm", false,
@@ -106,7 +119,7 @@ Examples:
 	return cmd
 }
 
-func deleteDisconnectedDevices(ctx context.Context, client *tsapi.Client, lastSeenTimeout time.Duration, excludedDevices []string, ephemeralOnly bool, confirm bool) (*DeletionSummary, error) {
+func deleteDisconnectedDevices(ctx context.Context, client *tsapi.Client, lastSeenTimeout time.Duration, excludedDevices []string, includedDevices []string, ephemeralOnly bool, confirm bool) (*DeletionSummary, error) {
 	// List all devices with full details to get ephemeral status
 	devices, err := client.Devices().ListWithAllFields(ctx)
 	if err != nil {
@@ -119,6 +132,12 @@ func deleteDisconnectedDevices(ctx context.Context, client *tsapi.Client, lastSe
 
 	// Filter devices based on criteria
 	for _, device := range devices {
+		// Check if the device matches the inclusion list (if specified)
+		if len(includedDevices) > 0 && !isIncluded(device.Name, includedDevices) {
+			skippedDevices = append(skippedDevices, fmt.Sprintf("%s (not included)", device.Name))
+			continue
+		}
+
 		// Check if the device is in the exclusion list by partial match
 		if isExcluded(device.Name, excludedDevices) {
 			skippedDevices = append(skippedDevices, fmt.Sprintf("%s (excluded)", device.Name))
@@ -205,6 +224,15 @@ func deleteDisconnectedDevices(ctx context.Context, client *tsapi.Client, lastSe
 func isExcluded(deviceName string, excludedList []string) bool {
 	for _, exclude := range excludedList {
 		if strings.Contains(deviceName, exclude) {
+			return true
+		}
+	}
+	return false
+}
+
+func isIncluded(deviceName string, includedList []string) bool {
+	for _, include := range includedList {
+		if strings.Contains(deviceName, include) {
 			return true
 		}
 	}

--- a/cmd/tscli/delete/devices/cli_test.go
+++ b/cmd/tscli/delete/devices/cli_test.go
@@ -1,0 +1,149 @@
+package devices
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	tsapi "tailscale.com/client/tailscale/v2"
+)
+
+type dummyRT struct {
+	devices []tsapi.Device
+}
+
+func (d *dummyRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp := map[string][]tsapi.Device{"devices": d.devices}
+	body, _ := json.Marshal(resp)
+	return &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestDeleteDevicesFlagValidation(t *testing.T) {
+	t.Parallel()
+
+	// Create a fake device that was last seen long ago
+	oldTime := time.Now().Add(-24 * time.Hour)
+	fakeDevices := []tsapi.Device{
+		{
+			ID:       "123",
+			NodeID:   "node-123",
+			Hostname: "test-device",
+			Name:     "test-device.tail123.ts.net",
+			OS:       "linux",
+			LastSeen: tsapi.Time{Time: oldTime},
+		},
+	}
+
+	stubClient := func() (*tsapi.Client, error) {
+		base, _ := url.Parse("http://fake")
+		return &tsapi.Client{
+			BaseURL: base,
+			HTTP:    &http.Client{Transport: &dummyRT{devices: fakeDevices}},
+		}, nil
+	}
+
+	cases := []struct {
+		name    string
+		args    []string
+		useStub bool
+		wantErr bool
+	}{
+		{"default dry run ok", []string{}, true, false},
+		{"unknown flag", []string{"--bogus"}, false, true},
+		{"exclude ok", []string{"--exclude", "prod"}, true, false},
+		{"include ok", []string{"--include", "test"}, true, false},
+		{"mutually exclusive", []string{"--exclude", "prod", "--include", "test"}, false, true},
+		{"multiple excludes ok", []string{"--exclude", "prod", "--exclude", "server"}, true, false},
+		{"multiple includes ok", []string{"--include", "dev", "--include", "test"}, true, false},
+		{"ephemeral flag ok", []string{"--ephemeral"}, true, false},
+		{"last-seen flag ok", []string{"--last-seen", "1h"}, true, false},
+		{"confirm flag ok", []string{"--confirm"}, true, false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			save := newClient
+			if tc.useStub {
+				newClient = stubClient
+			}
+			defer func() { newClient = save }()
+
+			cmd := Command()
+			cmd.SetArgs(tc.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+
+			err := cmd.ExecuteContext(context.Background())
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestIsIncluded(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		deviceName  string
+		includeList []string
+		want        bool
+	}{
+		{"empty list", "test-device", []string{}, false},
+		{"exact match", "test-device", []string{"test-device"}, true},
+		{"partial match", "test-device", []string{"test"}, true},
+		{"no match", "prod-server", []string{"test", "dev"}, false},
+		{"multiple patterns one match", "dev-machine", []string{"test", "dev"}, true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := isIncluded(tc.deviceName, tc.includeList)
+			if got != tc.want {
+				t.Fatalf("isIncluded(%q, %v) = %v, want %v", tc.deviceName, tc.includeList, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsExcluded(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		deviceName  string
+		excludeList []string
+		want        bool
+	}{
+		{"empty list", "test-device", []string{}, false},
+		{"exact match", "test-device", []string{"test-device"}, true},
+		{"partial match", "test-device", []string{"test"}, true},
+		{"no match", "prod-server", []string{"test", "dev"}, false},
+		{"multiple patterns one match", "dev-machine", []string{"test", "dev"}, true},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := isExcluded(tc.deviceName, tc.excludeList)
+			if got != tc.want {
+				t.Fatalf("isExcluded(%q, %v) = %v, want %v", tc.deviceName, tc.excludeList, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Add `--include` flag to `delete devices` command

### Summary

This PR adds an `--include` flag to the `tscli delete devices` command, allowing users to filter devices by name patterns for inclusion (complementing the existing `--exclude` flag).

### Changes

- Added `--include` flag that filters devices by partial name match (can be specified multiple times)
- Made `--include` and `--exclude` mutually exclusive to avoid confusing behavior
- Added `newClient` variable for dependency injection (consistent with `get/device`)
- Added comprehensive tests for flag validation and helper functions

### Usage

# Delete only devices matching specific patterns
tscli delete devices --last-seen 24h --include dev --include test --confirm

# Using exclude (existing behavior)
tscli delete devices --last-seen 24h --exclude prod --confirm

# Cannot use both (returns error)
tscli delete devices --include dev --exclude prod  # Error: mutually exclusive### Why mutually exclusive?

Using both `--include` and `--exclude` together can lead to confusing semantics (include first then exclude? or vice versa?). Keeping them mutually exclusive makes the behavior predictable and easy to understand.

### Testing

go test ./cmd/tscli/delete/devices/... -vAll tests pass, including:
- Flag validation tests (mutually exclusive check, multiple patterns, etc.)
- Unit tests for `isIncluded` and `isExcluded` helper functions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `--include` flag to `tscli delete devices` for device name filtering, making it mutually exclusive with `--exclude`, with tests added.
> 
>   - **Behavior**:
>     - Add `--include` flag to `tscli delete devices` for filtering devices by name patterns.
>     - Make `--include` and `--exclude` flags mutually exclusive in `cli.go`.
>   - **Functions**:
>     - Add `isIncluded()` function in `cli.go` to check device name inclusion.
>     - Modify `deleteDisconnectedDevices()` in `cli.go` to handle `include` logic.
>   - **Testing**:
>     - Add `TestDeleteDevicesFlagValidation` in `cli_test.go` for flag validation.
>     - Add `TestIsIncluded` and `TestIsExcluded` in `cli_test.go` for helper functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Ftscli&utm_source=github&utm_medium=referral)<sup> for 6fb5239f8f72c1d741ff0e38ea93aa961acb6b47. You can [customize](https://app.ellipsis.dev/jaxxstorm/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->