### PR TITLE
add setup prompts for output etc

### DIFF
--- a/cmd/tscli/config/setup/cli.go
+++ b/cmd/tscli/config/setup/cli.go
@@ -33,6 +33,8 @@ const (
 	stepSelectProfile     setupStep = "select-profile"
 	stepDeleteProfile     setupStep = "delete-profile"
 	stepAddAnother        setupStep = "add-another"
+	stepOutputChoice      setupStep = "output-choice"
+	stepDebugChoice       setupStep = "debug-choice"
 	stepDone              setupStep = "done"
 )
 
@@ -49,6 +51,9 @@ type model struct {
 	existingIdentity      *config.AgeIdentityFile
 	authType              string
 	profile               config.TailnetProfile
+	outputPreference      string
+	debugPreference       bool
+	initialSetup          bool
 	editing               bool
 	quitting              bool
 }
@@ -131,6 +136,9 @@ func newModel() (model, error) {
 		profiles:              profiles,
 		hasExistingEncryption: hasExistingEncryption,
 		useEncryption:         hasExistingEncryption,
+		outputPreference:      normalizeSetupOutput(viper.GetString("output")),
+		debugPreference:       viper.GetBool("debug"),
+		initialSetup:          len(profiles.Tailnets) == 0,
 	}
 
 	switch {
@@ -479,12 +487,46 @@ func (m model) submit() (tea.Model, tea.Cmd) {
 			m.step = stepAuthType
 			m.choiceIndex = 0
 		case "no":
+			if m.initialSetup {
+				m.step = stepOutputChoice
+				m.choiceIndex = outputChoiceIndex(m.outputPreference)
+				break
+			}
 			m.step = stepDone
 			m.message = strings.TrimSpace(m.message + " Setup complete.")
 			return m, tea.Quit
 		default:
 			m.err = fmt.Errorf("enter yes or no")
 		}
+	case stepOutputChoice:
+		outputPreference := parseSetupOutputChoice(value)
+		if outputPreference == "" {
+			m.err = fmt.Errorf("choose json, pretty, or human")
+			break
+		}
+		m.outputPreference = outputPreference
+		m.step = stepDebugChoice
+		m.choiceIndex = boolChoiceIndex(m.debugPreference)
+	case stepDebugChoice:
+		switch normalizeYesNo(value) {
+		case "yes":
+			m.debugPreference = true
+		case "no":
+			m.debugPreference = false
+		default:
+			m.err = fmt.Errorf("enter yes or no")
+			break
+		}
+		if err := config.SetPersistentValues(map[string]any{
+			"output": m.outputPreference,
+			"debug":  m.debugPreference,
+		}); err != nil {
+			m.err = err
+			break
+		}
+		m.step = stepDone
+		m.message = strings.TrimSpace(m.message + " Setup complete.")
+		return m, tea.Quit
 	case stepDone:
 		return m, tea.Quit
 	}
@@ -648,6 +690,10 @@ func (m model) View() string {
 		m.renderChoiceStep(&b, "Select a profile to delete", "[choose a profile]", m.input)
 	case stepAddAnother:
 		m.renderChoiceStep(&b, "Add another profile?", "[yes|no]", m.input)
+	case stepOutputChoice:
+		m.renderChoiceStep(&b, "Choose your default output format", "[json|pretty|human]", m.input)
+	case stepDebugChoice:
+		m.renderChoiceStep(&b, "Enable debug HTTP request/response logging by default?", "[yes|no]", m.input)
 	case stepDone:
 		if m.message == "" {
 			b.WriteString("Setup complete.")
@@ -684,6 +730,10 @@ func (m model) currentChoices() ([]choiceOption, bool) {
 		return choices, true
 	case stepAddAnother:
 		return []choiceOption{{value: "yes", label: "Add another profile"}, {value: "no", label: "Finish setup"}}, true
+	case stepOutputChoice:
+		return []choiceOption{{value: "json", label: "JSON"}, {value: "pretty", label: "Pretty"}, {value: "human", label: "Human"}}, true
+	case stepDebugChoice:
+		return []choiceOption{{value: "yes", label: "Yes, enable debug logging"}, {value: "no", label: "No, keep debug logging disabled"}}, true
 	default:
 		return nil, false
 	}
@@ -758,6 +808,44 @@ func normalizeAuthType(value string) string {
 	default:
 		return ""
 	}
+}
+
+func normalizeSetupOutput(value string) string {
+	if normalized := parseSetupOutputChoice(value); normalized != "" {
+		return normalized
+	}
+	return "json"
+}
+
+func parseSetupOutputChoice(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "json":
+		return "json"
+	case "pretty":
+		return "pretty"
+	case "human":
+		return "human"
+	default:
+		return ""
+	}
+}
+
+func outputChoiceIndex(value string) int {
+	switch normalizeSetupOutput(value) {
+	case "pretty":
+		return 1
+	case "human":
+		return 2
+	default:
+		return 0
+	}
+}
+
+func boolChoiceIndex(value bool) int {
+	if value {
+		return 0
+	}
+	return 1
 }
 
 func resolveAgeKeyPath(value string) (string, error) {

--- a/cmd/tscli/config/setup/cli.go
+++ b/cmd/tscli/config/setup/cli.go
@@ -64,7 +64,7 @@ func Command() *cobra.Command {
 		Short: "Interactive config setup",
 		Long:  "Launch an interactive Bubble Tea setup flow for optional AGE encryption and tailnet profile management.",
 		Example: "tscli config setup\n" +
-			"tscli config setup  # rerun later to add or delete profiles",
+			"tscli config setup  # rerun later to manage profiles or preferences",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			m, err := newModel()
 			if err != nil {
@@ -238,12 +238,15 @@ func (m model) submit() (tea.Model, tea.Cmd) {
 			}
 			m.step = stepDeleteProfile
 			m.choiceIndex = 0
+		case "settings":
+			m.step = stepOutputChoice
+			m.choiceIndex = outputChoiceIndex(m.outputPreference)
 		case "quit":
 			m.step = stepDone
 			m.message = "Setup complete."
 			return m, tea.Quit
 		default:
-			m.err = fmt.Errorf("choose add, modify, delete, or quit")
+			m.err = fmt.Errorf("choose add, modify, delete, settings, or quit")
 		}
 	case stepEncryptionChoice:
 		switch normalizeYesNo(value) {
@@ -626,7 +629,7 @@ func (m model) View() string {
 
 	switch m.step {
 	case stepActionChoice:
-		m.renderChoiceStep(&b, "Add, modify, or delete profiles?", "[add|modify|delete|quit]", m.input)
+		m.renderChoiceStep(&b, "Manage profiles or preferences?", "[add|modify|delete|settings|quit]", m.input)
 	case stepEncryptionChoice:
 		m.renderChoiceStep(&b, "Encrypt your credentials?", "[yes|no]", m.input)
 	case stepKeyPath:
@@ -711,7 +714,7 @@ type choiceOption struct {
 func (m model) currentChoices() ([]choiceOption, bool) {
 	switch m.step {
 	case stepActionChoice:
-		return []choiceOption{{value: "add", label: "Add profile"}, {value: "modify", label: "Modify profile"}, {value: "delete", label: "Delete profile"}, {value: "quit", label: "Quit"}}, true
+		return []choiceOption{{value: "add", label: "Add profile"}, {value: "modify", label: "Modify profile"}, {value: "delete", label: "Delete profile"}, {value: "settings", label: "Modify preferences"}, {value: "quit", label: "Quit"}}, true
 	case stepEncryptionChoice:
 		return []choiceOption{{value: "yes", label: "Yes, encrypt persisted credentials"}, {value: "no", label: "No, keep credentials in plaintext"}}, true
 	case stepReuseExistingKey:
@@ -781,7 +784,9 @@ func normalizeChoice(value string) string {
 		return "modify"
 	case "d", "delete", "3":
 		return "delete"
-	case "q", "quit", "exit", "4":
+	case "s", "settings", "prefs", "preferences", "4":
+		return "settings"
+	case "q", "quit", "exit", "5":
 		return "quit"
 	default:
 		return ""

--- a/cmd/tscli/config/setup/cli_test.go
+++ b/cmd/tscli/config/setup/cli_test.go
@@ -117,6 +117,68 @@ func TestAddAnotherNoTransitionsToDone(t *testing.T) {
 	}
 }
 
+func TestInitialSetupAddAnotherNoTransitionsToOutputChoice(t *testing.T) {
+	m := model{step: stepAddAnother, message: "Tailnet profile sandbox created.", initialSetup: true}
+	m.input = "no"
+
+	updatedModel, cmd := m.submit()
+	updated := updatedModel.(model)
+	if cmd != nil {
+		t.Fatalf("expected no quit command")
+	}
+	if updated.step != stepOutputChoice {
+		t.Fatalf("expected output choice step, got %q", updated.step)
+	}
+	if updated.choiceIndex != 0 {
+		t.Fatalf("expected json output choice by default, got %d", updated.choiceIndex)
+	}
+}
+
+func TestInitialSetupDebugChoicePersistsPreferences(t *testing.T) {
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	m := model{
+		step:             stepDebugChoice,
+		message:          "Tailnet profile sandbox created.",
+		initialSetup:     true,
+		outputPreference: "human",
+	}
+	m.input = "yes"
+
+	updatedModel, cmd := m.submit()
+	updated := updatedModel.(model)
+	if updated.err != nil {
+		t.Fatalf("expected no error, got %v", updated.err)
+	}
+	if updated.step != stepDone {
+		t.Fatalf("expected done step, got %q", updated.step)
+	}
+	if !updated.debugPreference {
+		t.Fatalf("expected debug preference to be enabled")
+	}
+	if cmd == nil {
+		t.Fatalf("expected quit command")
+	}
+	if msg := cmd(); msg != tea.Quit() {
+		t.Fatalf("expected tea quit command, got %v", msg)
+	}
+
+	cfg, err := os.ReadFile(filepath.Join(home, ".tscli.yaml"))
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	body := string(cfg)
+	if !strings.Contains(body, "output: human") {
+		t.Fatalf("expected output preference in config, got:\n%s", body)
+	}
+	if !strings.Contains(body, "debug: true") {
+		t.Fatalf("expected debug preference in config, got:\n%s", body)
+	}
+}
+
 func TestSelectProfileUsesCurrentSelection(t *testing.T) {
 	m := model{
 		step: stepSelectProfile,

--- a/cmd/tscli/config/setup/cli_test.go
+++ b/cmd/tscli/config/setup/cli_test.go
@@ -179,6 +179,38 @@ func TestInitialSetupDebugChoicePersistsPreferences(t *testing.T) {
 	}
 }
 
+func TestActionChoiceSettingsTransitionsToOutputChoice(t *testing.T) {
+	m := model{step: stepActionChoice, outputPreference: "human"}
+	m.input = "settings"
+
+	updatedModel, cmd := m.submit()
+	updated := updatedModel.(model)
+	if cmd != nil {
+		t.Fatalf("expected no quit command")
+	}
+	if updated.step != stepOutputChoice {
+		t.Fatalf("expected output choice step, got %q", updated.step)
+	}
+	if updated.choiceIndex != 2 {
+		t.Fatalf("expected human output choice index, got %d", updated.choiceIndex)
+	}
+}
+
+func TestActionChoiceIncludesPreferencesOption(t *testing.T) {
+	m := model{step: stepActionChoice}
+
+	choices, ok := m.currentChoices()
+	if !ok {
+		t.Fatalf("expected action choice options")
+	}
+	if len(choices) != 5 {
+		t.Fatalf("expected five action choices, got %d", len(choices))
+	}
+	if choices[3].value != "settings" || choices[3].label != "Modify preferences" {
+		t.Fatalf("unexpected preferences choice: %+v", choices[3])
+	}
+}
+
 func TestSelectProfileUsesCurrentSelection(t *testing.T) {
 	m := model{
 		step: stepSelectProfile,

--- a/docs/commands/tscli_config_setup.md
+++ b/docs/commands/tscli_config_setup.md
@@ -16,7 +16,7 @@ tscli config setup [flags]
 
 ```
 tscli config setup
-tscli config setup  # rerun later to add or delete profiles
+tscli config setup  # rerun later to manage profiles or preferences
 ```
 
 ### Options

--- a/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-15

--- a/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/design.md
+++ b/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/design.md
@@ -1,0 +1,73 @@
+## Context
+
+`tscli config setup` already walks users through encryption setup and profile creation, then persists profile state immediately through the existing `pkg/config` helpers. Global runtime defaults are split today: `output` is already a persisted config key, while `debug` is accepted from flags, env, or config at runtime but is currently stripped back out when config is rewritten. The requested change is cross-cutting because it touches the Bubble Tea setup state machine, non-interactive prompt flow, persisted config canonicalization, and command/runtime precedence expectations.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Extend initial `tscli config setup` so, after profile creation is finished, the flow asks for a default output mode with curated choices `json`, `pretty`, and `human`.
+- Prompt in the same setup flow for whether debug HTTP request/response logging should be enabled by default.
+- Persist the selected `output` and `debug` values in the config file without disturbing profile, tailnet, or encryption persistence.
+- Preserve existing precedence: command flags override environment variables, environment variables override saved config defaults.
+- Cover the new flow with unit and command-level integration tests.
+
+**Non-Goals:**
+- Changing the global output system or removing support for other formats such as `yaml` outside setup.
+- Reworking the existing rerun profile-management flow beyond what is needed to keep initial setup behavior correct.
+- Changing debug logging behavior itself; this change only adds setup-time preference capture and persistence.
+
+## Decisions
+
+### Add explicit post-profile setup steps for output and debug
+The setup model will gain two new choice-driven steps after initial profile creation is complete: one for output mode and one for debug preference. They will run only for the initial setup path, after the user declines to add another profile, which matches the requested sequencing of "after setting up profiles during initial setup."
+
+Rationale:
+- This keeps profile collection focused on authentication data.
+- It preserves current rerun flows for add/modify/delete profiles instead of unexpectedly prompting for global preferences during routine profile management.
+
+Alternative considered:
+- Prompt for output/debug before profile creation. Rejected because the request explicitly places these prompts after profiles and because setup success is primarily blocked on credentials, not presentation preferences.
+
+### Persist preferences as top-level config values in the existing config file
+The setup flow will write `output` and `debug` into the same persisted config used for `active-tailnet`, `tailnets`, and `encryption.age.*`. `output` already fits the existing top-level config model. `debug` will be treated the same way rather than as a setup-only special case.
+
+Rationale:
+- Users expect setup-selected defaults to survive later invocations.
+- Keeping the values top-level matches current runtime Viper lookup behavior and avoids introducing a new nested settings schema.
+
+Alternative considered:
+- Trigger existing `config set` subcommands from setup. Rejected because setup already writes config directly through shared helpers, and bouncing through command execution would add indirection and test complexity.
+
+### Update config canonicalization to preserve persisted debug values
+`pkg/config` currently drops `debug` when writing settings. The implementation should preserve boolean `debug` values during canonicalization while still excluding transient keys such as `help` and `base-url`. This is necessary so setup-written debug preferences survive later profile or encryption rewrites.
+
+Rationale:
+- Without this change, a setup prompt for debug would appear to succeed but would be silently lost on save.
+- The change is minimal and local to existing persistence rules.
+
+Alternative considered:
+- Store debug as a string or custom nested config key. Rejected because runtime already consumes `debug` directly as a boolean and no new schema is needed.
+
+### Keep setup choices curated while leaving broader manual configuration intact
+The setup prompt will offer `json`, `pretty`, and `human` only, even though manual config or flags may still accept other supported output formats.
+
+Rationale:
+- This matches the requested UX and keeps the first-run prompt simple.
+- It avoids broadening this change into output-format policy work.
+
+Alternative considered:
+- Expose every currently supported output mode in setup. Rejected because the request explicitly names the three desired choices.
+
+### Testing will cover both setup persistence and precedence safety
+Add unit coverage for setup-model transitions and config canonicalization, plus command-level integration tests for initial setup persistence and runtime overrides through flags or environment variables.
+
+Rationale:
+- The change spans both interactive flow behavior and persisted config semantics.
+- Precedence regressions would be user-visible and could break scripts.
+
+## Risks / Trade-offs
+
+- [Persisted `debug` changes config rewrite behavior] -> Mitigation: limit the canonicalization change to preserving explicit boolean debug values and add regression tests for config rewrites that already cover canonical profile persistence.
+- [Initial-setup-only gating could be implemented in the wrong branch and prompt during reruns] -> Mitigation: derive the condition from whether setup started without existing profiles and add integration coverage for both first-run and rerun flows.
+- [Setup prompt choices diverge from other accepted output formats] -> Mitigation: document that setup exposes a curated subset and leave manual `config set` or direct config editing available for advanced cases.
+- [Immediate profile saves happen before final preference prompts] -> Mitigation: write the preference values as a final persistence step after profile creation completes, using the same config file so the finished setup remains atomic from the user's perspective.

--- a/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/proposal.md
+++ b/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`tscli config setup` can already provision encryption and profiles, but it still leaves global CLI defaults for `output` and `debug` to be configured separately. That creates an incomplete first-run experience and makes it easy for users to miss the output mode that best fits either scripts or interactive use.
+
+## What Changes
+
+- Extend `tscli config setup` so the initial setup flow prompts for a default output mode after profile creation, with explicit choices for `json`, `pretty`, and `human`.
+- Extend `tscli config setup` so the initial setup flow also prompts whether debug HTTP request/response logging should be enabled by default.
+- Persist the selected `output` and `debug` settings in config alongside the profile and encryption settings written by setup.
+- Keep the existing `--output`, `TSCLI_OUTPUT`, `--debug`, and `TSCLI_DEBUG` overrides unchanged so scripts and one-off command invocations continue to take precedence over saved defaults.
+
+## Capabilities
+
+### New Capabilities
+- `cli-default-output-and-debug`: Define persisted global CLI defaults for output formatting and debug logging, including how config-backed defaults interact with flags and environment variables.
+
+### Modified Capabilities
+- `interactive-config-setup`: Update the guided setup flow so initial setup collects output and debug preferences after profile setup completes.
+- `multi-tailnet-config-profiles`: Update setup-driven config persistence requirements so setup can save global `output` and `debug` preferences in the same persisted config used for profiles.
+
+## Impact
+
+- Affected command group: `config setup`.
+- Affected flags and env keys: `--output`, `TSCLI_OUTPUT`, `--debug`, `TSCLI_DEBUG`.
+- Affected persisted config keys: `output`, `debug`, `active-tailnet`, `tailnets`, and existing `encryption.age.*` keys written by setup.
+- Backward compatibility: existing scripts keep working because explicit flags and environment variables still override saved defaults; existing config files remain valid when `output` or `debug` are absent.
+- Likely affected code: Bubble Tea setup flow under `cmd/tscli/config/setup/`, persisted config handling under `pkg/config/`, and tests covering setup and runtime config precedence.

--- a/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/specs/cli-default-output-and-debug/spec.md
+++ b/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/specs/cli-default-output-and-debug/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: CLI supports persisted default output and debug preferences
+The CLI SHALL support top-level persisted `output` and `debug` config keys as default runtime preferences. `output` SHALL accept setup-selected values `json`, `pretty`, and `human`. `debug` SHALL be persisted as a boolean that controls default HTTP request/response logging. For operational commands, effective values SHALL resolve in this order: command flags, environment variables, persisted config values, built-in defaults.
+
+#### Scenario: Persisted output default is used when no override exists
+- **WHEN** a config file sets `output: pretty` and a command runs without `--output` or `TSCLI_OUTPUT`
+- **THEN** the CLI SHALL use `pretty` as the effective output mode
+
+#### Scenario: Persisted debug default is used when no override exists
+- **WHEN** a config file sets `debug: true` and a command runs without `--debug` or `TSCLI_DEBUG`
+- **THEN** the CLI SHALL enable debug HTTP request/response logging for that command
+
+#### Scenario: Output flag overrides persisted default
+- **WHEN** a config file sets `output: pretty` and a command runs with `--output json`
+- **THEN** the CLI SHALL use `json` as the effective output mode
+
+#### Scenario: Output environment overrides persisted default
+- **WHEN** a config file sets `output: pretty` and a command runs with `TSCLI_OUTPUT=human`
+- **THEN** the CLI SHALL use `human` as the effective output mode
+
+#### Scenario: Debug environment overrides persisted default
+- **WHEN** a config file sets `debug: false` and a command runs with `TSCLI_DEBUG=1`
+- **THEN** the CLI SHALL enable debug HTTP request/response logging for that command
+
+#### Scenario: Missing persisted preferences fall back to built-in defaults
+- **WHEN** `output` and `debug` are absent from config and no flag or environment override is set
+- **THEN** the CLI SHALL keep its existing built-in runtime defaults

--- a/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/specs/interactive-config-setup/spec.md
+++ b/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/specs/interactive-config-setup/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Config setup provisions and manages profiles interactively
+After the encryption decision, `tscli config setup` SHALL prompt the user to choose API-key or OAuth credentials, collect the corresponding values, persist the resulting profile, ask whether another profile should be added, and on rerun SHALL offer management actions that include adding and deleting profiles. When the command starts without existing profiles and the user finishes profile creation, the setup flow SHALL then prompt for a default `output` mode with choices `json`, `pretty`, and `human`, prompt whether debug HTTP request/response logging should be enabled by default, persist those preferences, and only then exit the setup flow.
+
+#### Scenario: Setup creates an API-key profile
+- **WHEN** the user selects API-key authentication and enters a profile name and API key
+- **THEN** the CLI SHALL persist an API-key-backed profile
+- **AND** if encryption is enabled, the stored API key SHALL be encrypted before persistence
+
+#### Scenario: Setup creates an OAuth profile
+- **WHEN** the user selects OAuth authentication and enters a profile name, OAuth client ID, and OAuth client secret
+- **THEN** the CLI SHALL persist an OAuth-backed profile
+- **AND** if encryption is enabled, the stored OAuth client secret SHALL be encrypted before persistence
+
+#### Scenario: Setup supports adding multiple profiles in one session
+- **WHEN** the user finishes creating a profile and chooses to add another
+- **THEN** the CLI SHALL restart the credential-type and profile-entry steps within the same setup session
+
+#### Scenario: Initial setup prompts for output mode after profile creation
+- **WHEN** the command starts without existing profiles, the user finishes creating profiles, and declines to add another
+- **THEN** the CLI SHALL prompt for a default output mode after profile setup completes
+- **AND** the available setup choices SHALL be `json`, `pretty`, and `human`
+
+#### Scenario: Initial setup prompts for debug preference after output selection
+- **WHEN** the command starts without existing profiles and the user selects a default output mode in setup
+- **THEN** the CLI SHALL prompt whether debug HTTP request/response logging should be enabled by default before setup exits
+
+#### Scenario: Setup exits cleanly after collecting initial preferences
+- **WHEN** the command starts without existing profiles, the user completes profile creation, selects an output mode, and answers the debug preference prompt
+- **THEN** the CLI SHALL persist the completed changes
+- **AND** the CLI SHALL exit the setup flow gracefully
+
+#### Scenario: Rerun offers profile management actions
+- **WHEN** the user runs `tscli config setup` and at least one profile already exists
+- **THEN** the CLI SHALL present management options that include adding a new profile and deleting an existing profile
+
+#### Scenario: Rerun deletes a selected profile
+- **WHEN** the user chooses the delete action and selects a removable profile
+- **THEN** the CLI SHALL remove the selected profile from persisted config
+- **AND** the CLI SHALL exit or continue according to the user's follow-up choice

--- a/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/specs/multi-tailnet-config-profiles/spec.md
+++ b/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/specs/multi-tailnet-config-profiles/spec.md
@@ -1,0 +1,55 @@
+## MODIFIED Requirements
+
+### Requirement: Config commands manage tailnet profiles
+The `config` command group SHALL provide operations to list profiles, set active profile, upsert profile credentials, remove profiles, and run an interactive `config setup` flow for both API-key-backed and OAuth-backed profile entries. When secret encryption is enabled, profile mutation commands SHALL persist encrypted secret fields instead of plaintext secret fields. During initial `config setup`, after profile creation is complete, the command SHALL also persist the selected top-level `output` mode and `debug` preference in the config file.
+
+#### Scenario: List profiles displays active selection and auth shape
+- **WHEN** multiple profiles exist and one is active
+- **THEN** the list output SHALL include all profile names
+- **AND** the output SHALL indicate which profile is active
+- **AND** the output SHALL indicate whether each profile is API-key-backed or OAuth-backed
+
+#### Scenario: Set active profile validates existence
+- **WHEN** a user selects an active profile name that does not exist in `tailnets`
+- **THEN** the command SHALL fail with a validation error that names the missing profile
+
+#### Scenario: Upsert API-key profile writes persistent config
+- **WHEN** a user runs `config profiles set <name> --api-key <key>`
+- **THEN** the CLI SHALL persist an API-key-backed profile entry
+- **AND** the profile SHALL be available on the next command execution
+
+#### Scenario: Upsert OAuth profile writes persistent config
+- **WHEN** a user runs `config profiles set <name> --oauth-client-id <id> --oauth-client-secret <secret>`
+- **THEN** the CLI SHALL persist an OAuth-backed profile entry
+- **AND** the profile SHALL be available on the next command execution
+
+#### Scenario: Interactive setup writes encrypted API-key profile when encryption is configured
+- **WHEN** a user runs `config setup`, enables encryption, and saves an API-key-backed profile
+- **THEN** the saved config SHALL persist `api-key-encrypted` for that profile instead of plaintext `api-key`
+
+#### Scenario: Interactive setup writes encrypted OAuth profile when encryption is configured
+- **WHEN** a user runs `config setup`, enables encryption, and saves an OAuth-backed profile
+- **THEN** the saved config SHALL persist `oauth-client-secret-encrypted` for that profile instead of plaintext `oauth-client-secret`
+
+#### Scenario: Interactive setup writes output and debug preferences during initial setup
+- **WHEN** a user runs `config setup` with no existing profiles, completes profile creation, selects `pretty` or `human` or `json`, and chooses whether debug logging is enabled
+- **THEN** the saved config SHALL persist the selected top-level `output` value
+- **AND** the saved config SHALL persist the selected top-level `debug` boolean value
+
+#### Scenario: Upsert command writes encrypted secret fields when encryption is enabled
+- **WHEN** a user runs `config profiles set` for an API-key-backed or OAuth-backed profile while secret encryption is enabled
+- **THEN** the saved config SHALL persist ciphertext in the matching `*-encrypted` secret field
+- **AND** the saved config SHALL omit the plaintext secret field for that profile
+
+#### Scenario: Profile mutations keep canonical file shape
+- **WHEN** a user runs `config profiles set`, `config profiles set-active`, or `config setup`
+- **THEN** the saved config SHALL retain the selected `active-tailnet` and `tailnets` entries
+- **AND** the saved config SHALL NOT add or refresh duplicated top-level `tailnet` and `api-key` keys for the active profile
+
+#### Scenario: Remove active profile is blocked
+- **WHEN** a user attempts to remove the currently active profile without first selecting another profile
+- **THEN** the command SHALL fail with guidance to switch active profile first
+
+#### Scenario: Interactive setup deletes a non-active profile
+- **WHEN** a user reruns `config setup`, chooses delete, and selects a non-active profile
+- **THEN** the CLI SHALL remove that profile from persisted config

--- a/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/tasks.md
+++ b/openspec/changes/archive/2026-04-15-prompt-setup-output-and-debug/tasks.md
@@ -1,0 +1,18 @@
+## 1. Persisted Preferences
+
+- [x] 1.1 Update `pkg/config` persistence helpers so top-level `debug` values are preserved when config is rewritten while transient keys such as `help` and `base-url` remain excluded.
+- [x] 1.2 Add or extend config persistence tests to cover saved `output` and `debug` values alongside canonical profile-backed config writes.
+- [x] 1.3 Add or extend runtime precedence tests to verify saved `output` and `debug` defaults remain overridable by `--output`, `TSCLI_OUTPUT`, `--debug`, and `TSCLI_DEBUG`.
+
+## 2. Setup Flow Changes
+
+- [x] 2.1 Extend the `config setup` model with post-profile choice steps for output mode (`json`, `pretty`, `human`) and debug preference.
+- [x] 2.2 Gate the new prompts so they run after initial profile creation completes, but do not interrupt existing rerun profile-management flows.
+- [x] 2.3 Persist the selected output/debug preferences at the end of initial setup without regressing profile or encryption persistence.
+- [x] 2.4 Update setup rendering and any command help or example text needed to reflect the new initial-setup prompts.
+
+## 3. Verification
+
+- [x] 3.1 Add unit tests for setup-model transitions covering the initial-setup path from profile creation through output and debug prompts.
+- [x] 3.2 Add command-level integration coverage for first-run `config setup` persisting profile, `output`, and `debug` selections.
+- [x] 3.3 Add command-level integration coverage confirming rerun `config setup` profile-management flows do not unexpectedly require the new preference prompts.

--- a/openspec/specs/cli-default-output-and-debug/spec.md
+++ b/openspec/specs/cli-default-output-and-debug/spec.md
@@ -1,0 +1,32 @@
+## Purpose
+
+Define persisted top-level CLI defaults for `output` and `debug`, including how runtime precedence resolves against flags and environment variables.
+
+## Requirements
+
+### Requirement: CLI supports persisted default output and debug preferences
+The CLI SHALL support top-level persisted `output` and `debug` config keys as default runtime preferences. `output` SHALL accept setup-selected values `json`, `pretty`, and `human`. `debug` SHALL be persisted as a boolean that controls default HTTP request/response logging. For operational commands, effective values SHALL resolve in this order: command flags, environment variables, persisted config values, built-in defaults.
+
+#### Scenario: Persisted output default is used when no override exists
+- **WHEN** a config file sets `output: pretty` and a command runs without `--output` or `TSCLI_OUTPUT`
+- **THEN** the CLI SHALL use `pretty` as the effective output mode
+
+#### Scenario: Persisted debug default is used when no override exists
+- **WHEN** a config file sets `debug: true` and a command runs without `--debug` or `TSCLI_DEBUG`
+- **THEN** the CLI SHALL enable debug HTTP request/response logging for that command
+
+#### Scenario: Output flag overrides persisted default
+- **WHEN** a config file sets `output: pretty` and a command runs with `--output json`
+- **THEN** the CLI SHALL use `json` as the effective output mode
+
+#### Scenario: Output environment overrides persisted default
+- **WHEN** a config file sets `output: pretty` and a command runs with `TSCLI_OUTPUT=human`
+- **THEN** the CLI SHALL use `human` as the effective output mode
+
+#### Scenario: Debug environment overrides persisted default
+- **WHEN** a config file sets `debug: false` and a command runs with `TSCLI_DEBUG=1`
+- **THEN** the CLI SHALL enable debug HTTP request/response logging for that command
+
+#### Scenario: Missing persisted preferences fall back to built-in defaults
+- **WHEN** `output` and `debug` are absent from config and no flag or environment override is set
+- **THEN** the CLI SHALL keep its existing built-in runtime defaults

--- a/openspec/specs/interactive-config-setup/spec.md
+++ b/openspec/specs/interactive-config-setup/spec.md
@@ -57,7 +57,7 @@ When the user enables encryption in `tscli config setup`, the CLI SHALL prompt f
 - **AND** the CLI SHALL leave `encryption.age.public-key` and `encryption.age.private-key-path` unchanged when they were not already configured
 
 ### Requirement: Config setup provisions and manages profiles interactively
-After the encryption decision, `tscli config setup` SHALL prompt the user to choose API-key or OAuth credentials, collect the corresponding values, persist the resulting profile, ask whether another profile should be added, and on rerun SHALL offer management actions that include adding and deleting profiles.
+After the encryption decision, `tscli config setup` SHALL prompt the user to choose API-key or OAuth credentials, collect the corresponding values, persist the resulting profile, ask whether another profile should be added, and on rerun SHALL offer management actions that include adding and deleting profiles. When the command starts without existing profiles and the user finishes profile creation, the setup flow SHALL then prompt for a default `output` mode with choices `json`, `pretty`, and `human`, prompt whether debug HTTP request/response logging should be enabled by default, persist those preferences, and only then exit the setup flow.
 
 #### Scenario: Setup creates an API-key profile
 - **WHEN** the user selects API-key authentication and enters a profile name and API key
@@ -73,9 +73,19 @@ After the encryption decision, `tscli config setup` SHALL prompt the user to cho
 - **WHEN** the user finishes creating a profile and chooses to add another
 - **THEN** the CLI SHALL restart the credential-type and profile-entry steps within the same setup session
 
-#### Scenario: Setup exits cleanly after profile creation
-- **WHEN** the user finishes creating a profile and declines to add another
-- **THEN** the CLI SHALL exit the setup flow gracefully after persisting the completed changes
+#### Scenario: Initial setup prompts for output mode after profile creation
+- **WHEN** the command starts without existing profiles, the user finishes creating profiles, and declines to add another
+- **THEN** the CLI SHALL prompt for a default output mode after profile setup completes
+- **AND** the available setup choices SHALL be `json`, `pretty`, and `human`
+
+#### Scenario: Initial setup prompts for debug preference after output selection
+- **WHEN** the command starts without existing profiles and the user selects a default output mode in setup
+- **THEN** the CLI SHALL prompt whether debug HTTP request/response logging should be enabled by default before setup exits
+
+#### Scenario: Setup exits cleanly after collecting initial preferences
+- **WHEN** the command starts without existing profiles, the user completes profile creation, selects an output mode, and answers the debug preference prompt
+- **THEN** the CLI SHALL persist the completed changes
+- **AND** the CLI SHALL exit the setup flow gracefully
 
 #### Scenario: Rerun offers profile management actions
 - **WHEN** the user runs `tscli config setup` and at least one profile already exists

--- a/openspec/specs/multi-tailnet-config-profiles/spec.md
+++ b/openspec/specs/multi-tailnet-config-profiles/spec.md
@@ -89,7 +89,7 @@ Existing config files that only define `tailnet` and `api-key` SHALL continue to
 - **AND** the rewritten config SHALL NOT re-persist the duplicated flat `tailnet` and `api-key` values as part of the canonical profile representation
 
 ### Requirement: Config commands manage tailnet profiles
-The `config` command group SHALL provide operations to list profiles, set active profile, upsert profile credentials, remove profiles, and run an interactive `config setup` flow for both API-key-backed and OAuth-backed profile entries. When secret encryption is enabled, profile mutation commands SHALL persist encrypted secret fields instead of plaintext secret fields.
+The `config` command group SHALL provide operations to list profiles, set active profile, upsert profile credentials, remove profiles, and run an interactive `config setup` flow for both API-key-backed and OAuth-backed profile entries. When secret encryption is enabled, profile mutation commands SHALL persist encrypted secret fields instead of plaintext secret fields. During initial `config setup`, after profile creation is complete, the command SHALL also persist the selected top-level `output` mode and `debug` preference in the config file.
 
 #### Scenario: List profiles displays active selection and auth shape
 - **WHEN** multiple profiles exist and one is active
@@ -118,6 +118,11 @@ The `config` command group SHALL provide operations to list profiles, set active
 #### Scenario: Interactive setup writes encrypted OAuth profile when encryption is configured
 - **WHEN** a user runs `config setup`, enables encryption, and saves an OAuth-backed profile
 - **THEN** the saved config SHALL persist `oauth-client-secret-encrypted` for that profile instead of plaintext `oauth-client-secret`
+
+#### Scenario: Interactive setup writes output and debug preferences during initial setup
+- **WHEN** a user runs `config setup` with no existing profiles, completes profile creation, selects `pretty` or `human` or `json`, and chooses whether debug logging is enabled
+- **THEN** the saved config SHALL persist the selected top-level `output` value
+- **AND** the saved config SHALL persist the selected top-level `debug` boolean value
 
 #### Scenario: Upsert command writes encrypted secret fields when encryption is enabled
 - **WHEN** a user runs `config profiles set` for an API-key-backed or OAuth-backed profile while secret encryption is enabled

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,14 +42,24 @@ func save(v *viper.Viper) error {
 }
 
 func SetPersistentValue(key, value string) error {
+	return SetPersistentValues(map[string]any{key: value})
+}
+
+func SetPersistentBool(key string, value bool) error {
+	return SetPersistentValues(map[string]any{key: value})
+}
+
+func SetPersistentValues(values map[string]any) error {
 	v := viper.GetViper()
 
 	settings, err := loadPersistedSettings(v)
 	if err != nil {
 		return err
 	}
-	settings[key] = value
-	v.Set(key, value)
+	for key, value := range values {
+		settings[key] = value
+		v.Set(key, value)
+	}
 
 	return writePersistedSettings(v, settings)
 }
@@ -111,7 +121,7 @@ func canonicalizePersistedSettings(settings map[string]any) map[string]any {
 	canonical := make(map[string]any, len(settings))
 	for key, value := range settings {
 		switch key {
-		case "help", "debug", "base-url":
+		case "help", "base-url":
 			continue
 		default:
 			if isEmptyPersistedValue(value) {

--- a/pkg/config/encryption.go
+++ b/pkg/config/encryption.go
@@ -155,18 +155,6 @@ func decryptSecret(v *viper.Viper, ciphertext string) (string, error) {
 }
 
 func resolveAgeIdentity(v *viper.Viper) (age.Identity, error) {
-	if value, ok := os.LookupEnv("TSCLI_AGE_PRIVATE_KEY"); ok {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			return nil, fmt.Errorf("TSCLI_AGE_PRIVATE_KEY is set but empty")
-		}
-		identity, err := parseAgeIdentity(value)
-		if err != nil {
-			return nil, fmt.Errorf("invalid TSCLI_AGE_PRIVATE_KEY: %w", err)
-		}
-		return identity, nil
-	}
-
 	cfg := loadAgeEncryptionConfig(v)
 	if err := validateAgeEncryptionConfig(cfg); err != nil {
 		return nil, err
@@ -197,6 +185,18 @@ func resolveAgeIdentity(v *viper.Viper) (age.Identity, error) {
 		identity, err := age.ParseX25519Identity(cfg.PrivateKey)
 		if err != nil {
 			return nil, fmt.Errorf("invalid encryption.age.private-key: %w", err)
+		}
+		return identity, nil
+	}
+
+	if value, ok := os.LookupEnv("TSCLI_AGE_PRIVATE_KEY"); ok {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, fmt.Errorf("TSCLI_AGE_PRIVATE_KEY is set but empty")
+		}
+		identity, err := parseAgeIdentity(value)
+		if err != nil {
+			return nil, fmt.Errorf("invalid TSCLI_AGE_PRIVATE_KEY: %w", err)
 		}
 		return identity, nil
 	}

--- a/pkg/config/encryption_test.go
+++ b/pkg/config/encryption_test.go
@@ -79,6 +79,10 @@ func TestResolveRuntimeConfigDecryptsEncryptedProfileSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generate identity: %v", err)
 	}
+	wrongIdentity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("generate wrong identity: %v", err)
+	}
 
 	v := viper.New()
 	v.Set("encryption.age.public-key", identity.Recipient().String())
@@ -87,6 +91,7 @@ func TestResolveRuntimeConfigDecryptsEncryptedProfileSecrets(t *testing.T) {
 		t.Fatalf("write private key file: %v", err)
 	}
 	v.Set("encryption.age.private-key-path", privateKeyPath)
+	t.Setenv("TSCLI_AGE_PRIVATE_KEY", wrongIdentity.String())
 
 	ciphertext, err := encryptSecret(v, "tskey-encrypted")
 	if err != nil {

--- a/pkg/config/profiles_test.go
+++ b/pkg/config/profiles_test.go
@@ -589,12 +589,15 @@ func TestProfilePersistenceNormalizesMixedLegacyConfig(t *testing.T) {
 	if err := yaml.Unmarshal(cfg, &persisted); err != nil {
 		t.Fatalf("unmarshal normalized config: %v", err)
 	}
-	for _, unwanted := range []string{"tailnet", "api-key", "debug", "help"} {
+	for _, unwanted := range []string{"tailnet", "api-key", "help"} {
 		if _, ok := persisted[unwanted]; ok {
 			t.Fatalf("did not expect %q in normalized config:\n%s", unwanted, body)
 		}
 	}
 	if !strings.Contains(body, "output: pretty") {
 		t.Fatalf("expected unrelated persisted keys to remain, got:\n%s", body)
+	}
+	if !strings.Contains(body, "debug: false") {
+		t.Fatalf("expected persisted debug setting to remain, got:\n%s", body)
 	}
 }

--- a/test/cli/config_profiles_integration_test.go
+++ b/test/cli/config_profiles_integration_test.go
@@ -471,7 +471,7 @@ func TestConfigSetupRerunCanAddAndDeleteProfiles(t *testing.T) {
 	if res.err != nil {
 		t.Fatalf("config setup rerun delete: %v\nstderr:\n%s", res.err, res.stderr)
 	}
-	if !strings.Contains(res.stdout, "Add, modify, or delete profiles?") {
+	if !strings.Contains(res.stdout, "Manage profiles or preferences?") {
 		t.Fatalf("expected rerun management prompt, got:\n%s", res.stdout)
 	}
 	if strings.Contains(res.stdout, "Choose your default output format") || strings.Contains(res.stdout, "Enable debug HTTP request/response logging by default?") {
@@ -492,6 +492,46 @@ func TestConfigSetupRerunCanAddAndDeleteProfiles(t *testing.T) {
 	}
 	if strings.Contains(body, "name: org-admin") || strings.Contains(body, "oauth-client-id: cid") || strings.Contains(body, "oauth-client-secret-encrypted:") {
 		t.Fatalf("expected deleted oauth profile to be removed, got:\n%s", body)
+	}
+}
+
+func TestConfigSetupRerunCanModifyPreferences(t *testing.T) {
+	home := t.TempDir()
+
+	res := executeCLINoDefaultsWithInput(t, []string{"config", "setup"}, map[string]string{
+		"HOME": home,
+	}, "no\napi-key\nsandbox\n\ntskey-sandbox\nno\njson\nno\n")
+	if res.err != nil {
+		t.Fatalf("config setup initial run: %v\nstderr:\n%s", res.err, res.stderr)
+	}
+
+	res = executeCLINoDefaultsWithInput(t, []string{"config", "setup"}, map[string]string{
+		"HOME": home,
+	}, "settings\nhuman\nyes\n")
+	if res.err != nil {
+		t.Fatalf("config setup rerun settings: %v\nstderr:\n%s", res.err, res.stderr)
+	}
+	if !strings.Contains(res.stdout, "Manage profiles or preferences?") {
+		t.Fatalf("expected rerun management prompt, got:\n%s", res.stdout)
+	}
+	if !strings.Contains(res.stdout, "Choose your default output format") {
+		t.Fatalf("expected output preference prompt, got:\n%s", res.stdout)
+	}
+	if !strings.Contains(res.stdout, "Enable debug HTTP request/response logging by default?") {
+		t.Fatalf("expected debug preference prompt, got:\n%s", res.stdout)
+	}
+
+	configFile := filepath.Join(home, ".tscli.yaml")
+	cfg, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("read config file: %v", err)
+	}
+	body := string(cfg)
+	if !strings.Contains(body, "output: human") {
+		t.Fatalf("expected output preference to be updated, got:\n%s", body)
+	}
+	if !strings.Contains(body, "debug: true") {
+		t.Fatalf("expected debug preference to be updated, got:\n%s", body)
 	}
 }
 

--- a/test/cli/config_profiles_integration_test.go
+++ b/test/cli/config_profiles_integration_test.go
@@ -270,12 +270,15 @@ func TestConfigSetupCreatesPlaintextProfile(t *testing.T) {
 
 	res := executeCLINoDefaultsWithInput(t, []string{"config", "setup"}, map[string]string{
 		"HOME": home,
-	}, "no\napi-key\nsandbox\n\ntskey-sandbox\nno\n")
+	}, "no\napi-key\nsandbox\n\ntskey-sandbox\nno\njson\nno\n")
 	if res.err != nil {
 		t.Fatalf("config setup plaintext: %v\nstderr:\n%s", res.err, res.stderr)
 	}
 	if !strings.Contains(res.stdout, "Encrypt your credentials?") || !strings.Contains(res.stdout, "Use an API key (it will expire) or OAuth credentials?") {
 		t.Fatalf("expected setup prompts, got:\n%s", res.stdout)
+	}
+	if !strings.Contains(res.stdout, "Choose your default output format") || !strings.Contains(res.stdout, "Enable debug HTTP request/response logging by default?") {
+		t.Fatalf("expected output/debug prompts, got:\n%s", res.stdout)
 	}
 
 	configFile := filepath.Join(home, ".tscli.yaml")
@@ -287,6 +290,9 @@ func TestConfigSetupCreatesPlaintextProfile(t *testing.T) {
 	if !strings.Contains(body, "active-tailnet: sandbox") || !strings.Contains(body, "api-key: tskey-sandbox") {
 		t.Fatalf("expected plaintext profile in config file, got:\n%s", body)
 	}
+	if !strings.Contains(body, "output: json") || !strings.Contains(body, "debug: false") {
+		t.Fatalf("expected persisted output/debug defaults in config file, got:\n%s", body)
+	}
 	if strings.Contains(body, "api-key-encrypted:") {
 		t.Fatalf("did not expect encrypted api key in plaintext setup, got:\n%s", body)
 	}
@@ -297,7 +303,7 @@ func TestConfigSetupCreatesEncryptedProfileAndKeyFile(t *testing.T) {
 
 	res := executeCLINoDefaultsWithInput(t, []string{"config", "setup"}, map[string]string{
 		"HOME": home,
-	}, "yes\n\napi-key\nsandbox\n\ntskey-sandbox\nno\n")
+	}, "yes\n\napi-key\nsandbox\n\ntskey-sandbox\nno\npretty\nyes\n")
 	if res.err != nil {
 		t.Fatalf("config setup encrypted: %v\nstderr:\n%s", res.err, res.stderr)
 	}
@@ -319,6 +325,9 @@ func TestConfigSetupCreatesEncryptedProfileAndKeyFile(t *testing.T) {
 	body := string(cfg)
 	if !strings.Contains(body, "public-key:") || !strings.Contains(body, "private-key-path: "+keyFile) {
 		t.Fatalf("expected persisted encryption config, got:\n%s", body)
+	}
+	if !strings.Contains(body, "output: pretty") || !strings.Contains(body, "debug: true") {
+		t.Fatalf("expected persisted output/debug defaults, got:\n%s", body)
 	}
 	if !strings.Contains(body, "api-key-encrypted:") {
 		t.Fatalf("expected encrypted api key in config file, got:\n%s", body)
@@ -346,7 +355,7 @@ func TestConfigSetupReusesExistingAgeIdentityFile(t *testing.T) {
 
 	res := executeCLINoDefaultsWithInput(t, []string{"config", "setup"}, map[string]string{
 		"HOME": home,
-	}, "yes\n\nyes\napi-key\nsandbox\n\ntskey-sandbox\nno\n")
+	}, "yes\n\nyes\napi-key\nsandbox\n\ntskey-sandbox\nno\njson\nno\n")
 	if res.err != nil {
 		t.Fatalf("config setup reuse existing key: %v\nstderr:\n%s", res.err, res.stderr)
 	}
@@ -400,7 +409,7 @@ func TestConfigSetupCanReplaceExistingAgeIdentityFile(t *testing.T) {
 
 	res := executeCLINoDefaultsWithInput(t, []string{"config", "setup"}, map[string]string{
 		"HOME": home,
-	}, "yes\n\nno\napi-key\nsandbox\n\ntskey-sandbox\nno\n")
+	}, "yes\n\nno\napi-key\nsandbox\n\ntskey-sandbox\nno\njson\nno\n")
 	if res.err != nil {
 		t.Fatalf("config setup replace existing key: %v\nstderr:\n%s", res.err, res.stderr)
 	}
@@ -429,7 +438,7 @@ func TestConfigSetupInvalidExistingAgeIdentityFallsBackToGeneration(t *testing.T
 
 	res := executeCLINoDefaultsWithInput(t, []string{"config", "setup"}, map[string]string{
 		"HOME": home,
-	}, "yes\n\napi-key\nsandbox\n\ntskey-sandbox\nno\n")
+	}, "yes\n\napi-key\nsandbox\n\ntskey-sandbox\nno\njson\nno\n")
 	if res.err != nil {
 		t.Fatalf("config setup invalid existing key fallback: %v\nstderr:\n%s", res.err, res.stderr)
 	}
@@ -451,7 +460,7 @@ func TestConfigSetupRerunCanAddAndDeleteProfiles(t *testing.T) {
 
 	res := executeCLINoDefaultsWithInput(t, []string{"config", "setup"}, map[string]string{
 		"HOME": home,
-	}, "yes\n\napi-key\nsandbox\n\ntskey-sandbox\nyes\noauth\norg-admin\n\ncid\nsecret\nno\n")
+	}, "yes\n\napi-key\nsandbox\n\ntskey-sandbox\nyes\noauth\norg-admin\n\ncid\nsecret\nno\njson\nno\n")
 	if res.err != nil {
 		t.Fatalf("config setup initial run: %v\nstderr:\n%s", res.err, res.stderr)
 	}
@@ -464,6 +473,9 @@ func TestConfigSetupRerunCanAddAndDeleteProfiles(t *testing.T) {
 	}
 	if !strings.Contains(res.stdout, "Add, modify, or delete profiles?") {
 		t.Fatalf("expected rerun management prompt, got:\n%s", res.stdout)
+	}
+	if strings.Contains(res.stdout, "Choose your default output format") || strings.Contains(res.stdout, "Enable debug HTTP request/response logging by default?") {
+		t.Fatalf("did not expect initial setup preference prompts during rerun, got:\n%s", res.stdout)
 	}
 
 	configFile := filepath.Join(home, ".tscli.yaml")
@@ -488,7 +500,7 @@ func TestConfigSetupRerunCanModifySelectedProfile(t *testing.T) {
 
 	res := executeCLINoDefaultsWithInput(t, []string{"config", "setup"}, map[string]string{
 		"HOME": home,
-	}, "no\noauth\norg-admin\nexample.ts.net\ncid\nsecret\nno\n")
+	}, "no\noauth\norg-admin\nexample.ts.net\ncid\nsecret\nno\njson\nno\n")
 	if res.err != nil {
 		t.Fatalf("config setup initial run: %v\nstderr:\n%s", res.err, res.stderr)
 	}
@@ -501,6 +513,9 @@ func TestConfigSetupRerunCanModifySelectedProfile(t *testing.T) {
 	}
 	if !strings.Contains(res.stdout, "Select a profile to modify") {
 		t.Fatalf("expected modify selection prompt, got:\n%s", res.stdout)
+	}
+	if strings.Contains(res.stdout, "Choose your default output format") || strings.Contains(res.stdout, "Enable debug HTTP request/response logging by default?") {
+		t.Fatalf("did not expect initial setup preference prompts during rerun modify, got:\n%s", res.stdout)
 	}
 
 	configFile := filepath.Join(home, ".tscli.yaml")
@@ -751,7 +766,7 @@ func TestConfigShowNormalizesProfileBackedConfig(t *testing.T) {
 	if err := json.Unmarshal([]byte(res.stdout), &shown); err != nil {
 		t.Fatalf("unmarshal config show output: %v\noutput:\n%s", err, res.stdout)
 	}
-	for _, unwanted := range []string{"tailnet", "api-key", "debug", "help"} {
+	for _, unwanted := range []string{"tailnet", "api-key", "help"} {
 		if _, ok := shown[unwanted]; ok {
 			t.Fatalf("did not expect top-level %q in config show output: %s", unwanted, res.stdout)
 		}
@@ -761,6 +776,9 @@ func TestConfigShowNormalizesProfileBackedConfig(t *testing.T) {
 	}
 	if _, ok := shown["tailnets"]; !ok {
 		t.Fatalf("expected canonical profile keys in output, got %s", res.stdout)
+	}
+	if got, ok := shown["debug"].(bool); !ok || got {
+		t.Fatalf("expected persisted debug false in output, got %s", res.stdout)
 	}
 }
 

--- a/test/cli/example_output_test.go
+++ b/test/cli/example_output_test.go
@@ -343,7 +343,7 @@ func exampleOutputCases() []exampleOutputCase {
 			}
 			return []string{"config", "encryption", "setup", "--public-key", identity.Recipient().String(), "--private-key-source", "env"}
 		}, nil, "config encryption saved"),
-		localTextCaseWithInput("config setup", []string{"config", "setup"}, "no\napi-key\nsandbox\n\ntskey-sandbox\nno\n", nil, "Setup complete"),
+		localTextCaseWithInput("config setup", []string{"config", "setup"}, "no\napi-key\nsandbox\n\ntskey-sandbox\nno\njson\nno\n", nil, "Setup complete"),
 		localTextCase("config profiles delete", []string{"config", "profiles", "delete", "sandbox"}, setupProfileHome, "tailnet profile sandbox removed"),
 		localObjectCase("config profiles list", []string{"config", "profiles", "list"}, setupProfileHome, jsonShapeExpectation{
 			TopLevel:   jsonTopLevelObject,

--- a/test/cli/persistent_prerun_runtime_config_test.go
+++ b/test/cli/persistent_prerun_runtime_config_test.go
@@ -1,6 +1,7 @@
 package cli_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -193,4 +194,118 @@ func TestCommandsWithPreRunDecryptEncryptedActiveProfile(t *testing.T) {
 	if len(reqs) == 0 || !strings.Contains(reqs[0].Path, "/tailnet/sandbox/devices") {
 		t.Fatalf("expected encrypted profile request path, got %+v", reqs)
 	}
+}
+
+func TestSavedOutputDefaultCanBeOverriddenForRuntimeCommands(t *testing.T) {
+	home := t.TempDir()
+	configFile := filepath.Join(home, ".tscli.yaml")
+	cfg := strings.Join([]string{
+		"output: pretty",
+		"active-tailnet: profile-tailnet",
+		"tailnets:",
+		"  - name: profile-tailnet",
+		"    api-key: tskey-profile",
+		"",
+	}, "\n")
+	if err := os.WriteFile(configFile, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	runListDevices := func(t *testing.T, args []string, env map[string]string) execResult {
+		t.Helper()
+		mock := apimock.New(t)
+		mock.AddJSON(http.MethodGet, "/tailnet/profile-tailnet/devices", http.StatusOK, apimock.DeviceList())
+		env["HOME"] = home
+		env["TSCLI_BASE_URL"] = mock.URL()
+		return executeCLINoDefaults(t, args, env)
+	}
+
+	t.Run("saved pretty output is used by default", func(t *testing.T) {
+		res := runListDevices(t, []string{"list", "devices"}, map[string]string{})
+		if res.err != nil {
+			t.Fatalf("unexpected error: %v\nstderr:\n%s", res.err, res.stderr)
+		}
+		var out any
+		if err := json.Unmarshal([]byte(res.stdout), &out); err == nil {
+			t.Fatalf("expected non-json pretty output by default, got:\n%s", res.stdout)
+		}
+	})
+
+	t.Run("env output overrides saved default", func(t *testing.T) {
+		res := runListDevices(t, []string{"list", "devices"}, map[string]string{"TSCLI_OUTPUT": "json"})
+		if res.err != nil {
+			t.Fatalf("unexpected error: %v\nstderr:\n%s", res.err, res.stderr)
+		}
+		var out any
+		if err := json.Unmarshal([]byte(res.stdout), &out); err != nil {
+			t.Fatalf("expected json output from env override: %v\noutput:\n%s", err, res.stdout)
+		}
+	})
+
+	t.Run("flag output overrides saved default", func(t *testing.T) {
+		res := runListDevices(t, []string{"--output", "json", "list", "devices"}, map[string]string{})
+		if res.err != nil {
+			t.Fatalf("unexpected error: %v\nstderr:\n%s", res.err, res.stderr)
+		}
+		var out any
+		if err := json.Unmarshal([]byte(res.stdout), &out); err != nil {
+			t.Fatalf("expected json output from flag override: %v\noutput:\n%s", err, res.stdout)
+		}
+	})
+}
+
+func TestSavedDebugDefaultCanBeOverriddenForRuntimeCommands(t *testing.T) {
+	home := t.TempDir()
+	configFile := filepath.Join(home, ".tscli.yaml")
+	cfg := strings.Join([]string{
+		"output: json",
+		"debug: false",
+		"active-tailnet: profile-tailnet",
+		"tailnets:",
+		"  - name: profile-tailnet",
+		"    api-key: tskey-profile",
+		"",
+	}, "\n")
+	if err := os.WriteFile(configFile, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	runListDevices := func(t *testing.T, args []string, env map[string]string) execResult {
+		t.Helper()
+		mock := apimock.New(t)
+		mock.AddJSON(http.MethodGet, "/tailnet/profile-tailnet/devices", http.StatusOK, apimock.DeviceList())
+		env["HOME"] = home
+		env["TSCLI_BASE_URL"] = mock.URL()
+		return executeCLINoDefaults(t, args, env)
+	}
+
+	t.Run("saved debug false stays quiet by default", func(t *testing.T) {
+		res := runListDevices(t, []string{"list", "devices"}, map[string]string{})
+		if res.err != nil {
+			t.Fatalf("unexpected error: %v\nstderr:\n%s", res.err, res.stderr)
+		}
+		if strings.Contains(res.stderr, "HTTP/") || strings.Contains(res.stderr, "Authorization:") {
+			t.Fatalf("did not expect debug output by default, got:\n%s", res.stderr)
+		}
+	})
+
+	t.Run("env debug overrides saved default", func(t *testing.T) {
+		res := runListDevices(t, []string{"list", "devices"}, map[string]string{"TSCLI_DEBUG": "1"})
+		if res.err != nil {
+			t.Fatalf("unexpected error: %v\nstderr:\n%s", res.err, res.stderr)
+		}
+		if !strings.Contains(res.stderr, "HTTP/") {
+			t.Fatalf("expected debug output from env override, got:\n%s", res.stderr)
+		}
+	})
+
+	t.Run("flag debug overrides saved default", func(t *testing.T) {
+		res := runListDevices(t, []string{"--debug", "list", "devices"}, map[string]string{})
+		if res.err != nil {
+			t.Fatalf("unexpected error: %v\nstderr:\n%s", res.err, res.stderr)
+		}
+		if !strings.Contains(res.stderr, "HTTP/") {
+			t.Fatalf("expected debug output from flag override, got:\n%s", res.stderr)
+		}
+	})
 }


### PR DESCRIPTION
- **feat(config): add oauth-backed profiles and age secret encryption**
- **feat(config): add age key path and interactive profile setup**
- **feat(config): add interactive setup and age key reuse**
- **fix(config): block deleting the active tailnet profile**
- **fix(config): preserve encrypted profile auth and auth precedence**
- **test(config): cover interactive profile prompts**
- **feat(config): prompt for output and debug defaults in setup**
